### PR TITLE
Make the fontSize description a little clearer

### DIFF
--- a/lib/termination.coffee
+++ b/lib/termination.coffee
@@ -149,7 +149,7 @@ module.exports =
           default: ''
         fontSize:
           title: 'Font Size'
-          description: 'Override the terminal\'s default font size.'
+          description: 'Override the terminal\'s default font size. **Please enter a pixel integer value only, i.e `6` or `10`**'
           type: 'string'
           default: ''
         defaultPanelHeight:


### PR DESCRIPTION
Hello! 

If you enter `6px` or `1rem` it won't actually update the style. An extra tip in the description might help? Cheers!