### PR TITLE
Add PowerShell theme

### DIFF
--- a/lib/termination.coffee
+++ b/lib/termination.coffee
@@ -184,7 +184,8 @@ module.exports =
             'one-dark',
             'one-light',
             'bliss',
-            'gruvbox'
+            'gruvbox',
+            'PowerShell'
           ]
     iconColors:
       type: 'object'

--- a/lib/themes/PowerShell.coffee
+++ b/lib/themes/PowerShell.coffee
@@ -1,0 +1,19 @@
+module.exports =
+  normal:
+    black: '#000000'
+    red:'#990000'
+    green: '#00A600'
+    yellow: '#999900'
+    blue: '#0000B2'
+    magenta: '#B200B2'
+    cyan: '#00A6B2'
+    white: '#BFBFBF'
+  bright:
+    black: '#666666'
+    red: '#E50000'
+    green: '#00D900'
+    yellow: '#E5E500'
+    blue: '#0000FF'
+    magenta: '#E500E5'
+    cyan: '#00E5E5'
+    white: '#E5E5E5'

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -21,4 +21,5 @@
   @import 'themes/bliss';
   @import 'themes/gruvbox';
   @import 'themes/city-lights';
+  @import 'themes/PowerShell';
 }

--- a/styles/themes/PowerShell.less
+++ b/styles/themes/PowerShell.less
@@ -1,0 +1,9 @@
+.PowerShell {
+  background-color: rgb(1, 36, 86);
+  color: rgb(238, 237, 240);
+
+  .terminal-cursor {
+    background-color: white;
+    color: rgb(0, 128, 128);
+  }
+}


### PR DESCRIPTION
When I'm in Windows, I find the standard PowerShell colors a helpful reminder to use PowerShell syntax instead of Unix syntax:

![image](https://user-images.githubusercontent.com/1559108/149387694-b71fa7e4-a5d1-4233-91c7-a9445aca9a52.png)

This theme borrows those colors:

![image](https://user-images.githubusercontent.com/1559108/149388081-06bf6660-3578-4fca-a433-1870464e9405.png)
